### PR TITLE
Refactor to support multiple issuers.

### DIFF
--- a/oauth2/auth.go
+++ b/oauth2/auth.go
@@ -34,7 +34,7 @@ const (
 type Flow interface {
 	// Authorize obtains an authorization grant based on an OAuth 2.0 authorization flow.
 	// The method returns a grant which may contain an initial access token.
-	Authorize() (*AuthorizationGrant, error)
+	Authorize(audience string) (*AuthorizationGrant, error)
 }
 
 // AuthorizationGrantRefresher refreshes OAuth 2.0 authorization grant
@@ -59,8 +59,17 @@ type AuthorizationGrant struct {
 	// Type describes the type of authorization grant represented by this structure
 	Type AuthorizationGrantType `json:"type"`
 
+	// Audience is the intended audience of the access tokens
+	Audience string `json:"audience,omitempty"`
+
+	// ClientID is an OAuth2 client identifier used by some flows
+	ClientID string `json:"client_id,omitempty"`
+
 	// ClientCredentials is credentials data for the client credentials grant type
 	ClientCredentials *KeyFile `json:"client_credentials,omitempty"`
+
+	// the token endpoint
+	TokenEndpoint string `json:"token_endpoint"`
 
 	// Token contains an access token in the client credentials grant type,
 	// and a refresh token in the device authorization grant type

--- a/oauth2/auth_suite_test.go
+++ b/oauth2/auth_suite_test.go
@@ -57,3 +57,9 @@ func (te *MockTokenExchanger) ExchangeDeviceCode(ctx context.Context,
 	te.CalledWithRequest = &req
 	return te.ReturnsTokens, te.ReturnsError
 }
+
+var oidcEndpoints = OIDCWellKnownEndpoints{
+	AuthorizationEndpoint:       "http://issuer/auth/authorize",
+	TokenEndpoint:               "http://issuer/auth/token",
+	DeviceAuthorizationEndpoint: "http://issuer/auth/authorize/device",
+}

--- a/oauth2/authorization_tokenretriever.go
+++ b/oauth2/authorization_tokenretriever.go
@@ -32,8 +32,7 @@ import (
 // TokenRetriever implements AuthTokenExchanger in order to facilitate getting
 // Tokens
 type TokenRetriever struct {
-	oidcWellKnownEndpoints OIDCWellKnownEndpoints
-	transport              HTTPAuthTransport
+	transport HTTPAuthTransport
 }
 
 // AuthorizationTokenResponse is the HTTP response when asking for a new token.
@@ -50,33 +49,37 @@ type AuthorizationTokenResponse struct {
 // AuthorizationCodeExchangeRequest is used to request the exchange of an
 // authorization code for a token
 type AuthorizationCodeExchangeRequest struct {
-	ClientID     string
-	CodeVerifier string
-	Code         string
-	RedirectURI  string
+	TokenEndpoint string
+	ClientID      string
+	CodeVerifier  string
+	Code          string
+	RedirectURI   string
 }
 
 // RefreshTokenExchangeRequest is used to request the exchange of a refresh
 // token for a refreshed token
 type RefreshTokenExchangeRequest struct {
-	ClientID     string
-	RefreshToken string
+	TokenEndpoint string
+	ClientID      string
+	RefreshToken  string
 }
 
 // ClientCredentialsExchangeRequest is used to request the exchange of
 // client credentials for a token
 type ClientCredentialsExchangeRequest struct {
-	ClientID     string
-	ClientSecret string
-	Audience     string
+	TokenEndpoint string
+	ClientID      string
+	ClientSecret  string
+	Audience      string
 }
 
 // DeviceCodeExchangeRequest is used to request the exchange of
 // a device code for a token
 type DeviceCodeExchangeRequest struct {
-	ClientID     string
-	DeviceCode   string
-	PollInterval time.Duration
+	TokenEndpoint string
+	ClientID      string
+	DeviceCode    string
+	PollInterval  time.Duration
 }
 
 // TokenErrorResponse is used to parse error responses from the token endpoint
@@ -104,12 +107,9 @@ type HTTPAuthTransport interface {
 
 // NewTokenRetriever allows a TokenRetriever the internal of a new
 // TokenRetriever to be easily set up
-func NewTokenRetriever(
-	oidcWellKnownEndpoints OIDCWellKnownEndpoints,
-	authTransport HTTPAuthTransport) *TokenRetriever {
+func NewTokenRetriever(authTransport HTTPAuthTransport) *TokenRetriever {
 	return &TokenRetriever{
-		oidcWellKnownEndpoints: oidcWellKnownEndpoints,
-		transport:              authTransport,
+		transport: authTransport,
 	}
 }
 
@@ -127,7 +127,7 @@ func (ce *TokenRetriever) newExchangeCodeRequest(
 	euv := uv.Encode()
 
 	request, err := http.NewRequest("POST",
-		ce.oidcWellKnownEndpoints.TokenEndpoint,
+		req.TokenEndpoint,
 		strings.NewReader(euv),
 	)
 	if err != nil {
@@ -151,7 +151,7 @@ func (ce *TokenRetriever) newDeviceCodeExchangeRequest(
 	euv := uv.Encode()
 
 	request, err := http.NewRequest("POST",
-		ce.oidcWellKnownEndpoints.TokenEndpoint,
+		req.TokenEndpoint,
 		strings.NewReader(euv),
 	)
 	if err != nil {
@@ -175,7 +175,7 @@ func (ce *TokenRetriever) newRefreshTokenRequest(req RefreshTokenExchangeRequest
 	euv := uv.Encode()
 
 	request, err := http.NewRequest("POST",
-		ce.oidcWellKnownEndpoints.TokenEndpoint,
+		req.TokenEndpoint,
 		strings.NewReader(euv),
 	)
 	if err != nil {
@@ -200,7 +200,7 @@ func (ce *TokenRetriever) newClientCredentialsRequest(req ClientCredentialsExcha
 	euv := uv.Encode()
 
 	request, err := http.NewRequest("POST",
-		ce.oidcWellKnownEndpoints.TokenEndpoint,
+		req.TokenEndpoint,
 		strings.NewReader(euv),
 	)
 	if err != nil {

--- a/oauth2/authorization_tokenretriever_test.go
+++ b/oauth2/authorization_tokenretriever_test.go
@@ -49,13 +49,13 @@ func (t *MockTransport) Do(req *http.Request) (*http.Response, error) {
 var _ = Describe("CodetokenExchanger", func() {
 	Describe("newExchangeCodeRequest", func() {
 		It("creates the request", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "https://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 			exchangeRequest := AuthorizationCodeExchangeRequest{
-				ClientID:     "clientID",
-				CodeVerifier: "Verifier",
-				Code:         "code",
-				RedirectURI:  "https://redirect",
+				TokenEndpoint: "https://issuer/oauth/token",
+				ClientID:      "clientID",
+				CodeVerifier:  "Verifier",
+				Code:          "code",
+				RedirectURI:   "https://redirect",
 			}
 
 			result, err := tokenRetriever.newExchangeCodeRequest(exchangeRequest)
@@ -75,10 +75,11 @@ var _ = Describe("CodetokenExchanger", func() {
 		})
 
 		It("returns an error when NewRequest returns an error", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 
-			result, err := tokenRetriever.newExchangeCodeRequest(AuthorizationCodeExchangeRequest{})
+			result, err := tokenRetriever.newExchangeCodeRequest(AuthorizationCodeExchangeRequest{
+				TokenEndpoint: "://issuer/oauth/token",
+			})
 
 			Expect(result).To(BeNil())
 			Expect(err.Error()).To(Equal("parse ://issuer/oauth/token: missing protocol scheme"))
@@ -139,11 +140,11 @@ var _ = Describe("CodetokenExchanger", func() {
 
 	Describe("newRefreshTokenRequest", func() {
 		It("creates the request", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "https://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 			exchangeRequest := RefreshTokenExchangeRequest{
-				ClientID:     "clientID",
-				RefreshToken: "refreshToken",
+				TokenEndpoint: "https://issuer/oauth/token",
+				ClientID:      "clientID",
+				RefreshToken:  "refreshToken",
 			}
 
 			result, err := tokenRetriever.newRefreshTokenRequest(exchangeRequest)
@@ -161,10 +162,11 @@ var _ = Describe("CodetokenExchanger", func() {
 		})
 
 		It("returns an error when NewRequest returns an error", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 
-			result, err := tokenRetriever.newRefreshTokenRequest(RefreshTokenExchangeRequest{})
+			result, err := tokenRetriever.newRefreshTokenRequest(RefreshTokenExchangeRequest{
+				TokenEndpoint: "://issuer/oauth/token",
+			})
 
 			Expect(result).To(BeNil())
 			Expect(err.Error()).To(Equal("parse ://issuer/oauth/token: missing protocol scheme"))
@@ -173,12 +175,12 @@ var _ = Describe("CodetokenExchanger", func() {
 
 	Describe("newClientCredentialsRequest", func() {
 		It("creates the request", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "https://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 			exchangeRequest := ClientCredentialsExchangeRequest{
-				ClientID:     "clientID",
-				ClientSecret: "clientSecret",
-				Audience:     "audience",
+				TokenEndpoint: "https://issuer/oauth/token",
+				ClientID:      "clientID",
+				ClientSecret:  "clientSecret",
+				Audience:      "audience",
 			}
 
 			result, err := tokenRetriever.newClientCredentialsRequest(exchangeRequest)
@@ -197,10 +199,11 @@ var _ = Describe("CodetokenExchanger", func() {
 		})
 
 		It("returns an error when NewRequest returns an error", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 
-			result, err := tokenRetriever.newClientCredentialsRequest(ClientCredentialsExchangeRequest{})
+			result, err := tokenRetriever.newClientCredentialsRequest(ClientCredentialsExchangeRequest{
+				TokenEndpoint: "://issuer/oauth/token",
+			})
 
 			Expect(result).To(BeNil())
 			Expect(err.Error()).To(Equal("parse ://issuer/oauth/token: missing protocol scheme"))
@@ -209,12 +212,12 @@ var _ = Describe("CodetokenExchanger", func() {
 
 	Describe("newDeviceCodeExchangeRequest", func() {
 		It("creates the request", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "https://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 			exchangeRequest := DeviceCodeExchangeRequest{
-				ClientID:     "clientID",
-				DeviceCode:   "deviceCode",
-				PollInterval: time.Duration(5) * time.Second,
+				TokenEndpoint: "https://issuer/oauth/token",
+				ClientID:      "clientID",
+				DeviceCode:    "deviceCode",
+				PollInterval:  time.Duration(5) * time.Second,
 			}
 
 			result, err := tokenRetriever.newDeviceCodeExchangeRequest(exchangeRequest)
@@ -232,10 +235,11 @@ var _ = Describe("CodetokenExchanger", func() {
 		})
 
 		It("returns an error when NewRequest returns an error", func() {
-			tokenRetriever := TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "://issuer/oauth/token"}}
+			tokenRetriever := TokenRetriever{}
 
-			result, err := tokenRetriever.newClientCredentialsRequest(ClientCredentialsExchangeRequest{})
+			result, err := tokenRetriever.newClientCredentialsRequest(ClientCredentialsExchangeRequest{
+				TokenEndpoint: "://issuer/oauth/token",
+			})
 
 			Expect(result).To(BeNil())
 			Expect(err.Error()).To(Equal("parse ://issuer/oauth/token: missing protocol scheme"))
@@ -251,13 +255,13 @@ var _ = Describe("CodetokenExchanger", func() {
 		BeforeEach(func() {
 			mockTransport = &MockTransport{}
 			tokenRetriever = &TokenRetriever{
-				oidcWellKnownEndpoints: OIDCWellKnownEndpoints{TokenEndpoint: "https://issuer/oauth/token"},
-				transport:              mockTransport,
+				transport: mockTransport,
 			}
 			exchangeRequest = DeviceCodeExchangeRequest{
-				ClientID:     "clientID",
-				DeviceCode:   "deviceCode",
-				PollInterval: time.Duration(1) * time.Second,
+				TokenEndpoint: "https://issuer/oauth/token",
+				ClientID:      "clientID",
+				DeviceCode:    "deviceCode",
+				PollInterval:  time.Duration(1) * time.Second,
 			}
 			tokenResult = TokenResult{
 				ExpiresIn:    1,

--- a/oauth2/client_credentials_provider.go
+++ b/oauth2/client_credentials_provider.go
@@ -36,6 +36,7 @@ type KeyFile struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	ClientEmail  string `json:"client_email"`
+	IssuerURL    string `json:"issuer_url"`
 }
 
 func NewClientCredentialsProviderFromKeyFile(keyFile string) *KeyFileProvider {

--- a/oauth2/device_code_provider.go
+++ b/oauth2/device_code_provider.go
@@ -29,7 +29,7 @@ import (
 // DeviceCodeProvider holds the information needed to easily get a
 // device code locally.
 type LocalDeviceCodeProvider struct {
-	Issuer
+	options                LocalDeviceCodeProviderOptions
 	oidcWellKnownEndpoints OIDCWellKnownEndpoints
 	transport              HTTPAuthTransport
 }
@@ -50,13 +50,17 @@ type DeviceCodeResult struct {
 	Interval                int    `json:"interval"`
 }
 
+type LocalDeviceCodeProviderOptions struct {
+	ClientID string
+}
+
 // NewLocalDeviceCodeProvider allows for the easy setup of LocalDeviceCodeProvider
 func NewLocalDeviceCodeProvider(
-	issuer Issuer,
+	options LocalDeviceCodeProviderOptions,
 	oidcWellKnownEndpoints OIDCWellKnownEndpoints,
 	authTransport HTTPAuthTransport) *LocalDeviceCodeProvider {
 	return &LocalDeviceCodeProvider{
-		issuer,
+		options,
 		oidcWellKnownEndpoints,
 		authTransport,
 	}
@@ -65,11 +69,11 @@ func NewLocalDeviceCodeProvider(
 // GetCode obtains a new device code. Additional scopes
 // beyond openid and email can be sent by passing in arguments for
 // <additionalScopes>.
-func (cp *LocalDeviceCodeProvider) GetCode(additionalScopes ...string) (*DeviceCodeResult, error) {
+func (cp *LocalDeviceCodeProvider) GetCode(audience string, additionalScopes ...string) (*DeviceCodeResult, error) {
 	request, err := cp.newDeviceCodeRequest(&DeviceCodeRequest{
-		ClientID: cp.ClientID,
+		ClientID: cp.options.ClientID,
 		Scopes:   append([]string{"openid", "email"}, additionalScopes...),
-		Audience: cp.Audience,
+		Audience: audience,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- decouple the issuer parameter from the audience
- use issuer information that is in the keyfile
